### PR TITLE
fix: use urls in extends instead of relative paths

### DIFF
--- a/.changeset/cuddly-foxes-clap.md
+++ b/.changeset/cuddly-foxes-clap.md
@@ -1,0 +1,5 @@
+---
+'@sripwoud/dprint-config': patch
+---
+
+Use urls in extends instead of relative paths

--- a/packages/dprint/.dprint.jsonc
+++ b/packages/dprint/.dprint.jsonc
@@ -1,5 +1,8 @@
 {
-  "extends": [".dprint.ts.jsonc", ".dprint.yaml.jsonc"],
+  "extends": [
+    "https://raw.githubusercontent.com/sripwoud/configs/main/packages/dprint/.dprint.ts.jsonc",
+    "https://raw.githubusercontent.com/sripwoud/configs/main/packages/dprint/.dprint.yaml.jsonc"
+  ],
   "excludes": [
     "**/coverage",
     "**/build",

--- a/packages/dprint/package.json
+++ b/packages/dprint/package.json
@@ -3,12 +3,7 @@
   "version": "1.0.2",
   "description": "sripwoud's dprint configuration",
   "main": ".dprint.jsonc",
-  "files": [
-    ".dprint.ts.jsonc",
-    ".dprint.yaml.jsonc",
-    ".dprint.jsonc",
-    "postinstall.js"
-  ],
+  "files": [".dprint.jsonc", "postinstall.js"],
   "keywords": [
     "formatter",
     "dprint",


### PR DESCRIPTION
- **fix: use urls in extends instead of relative paths**
- **chore: do not include `.dprint.{ts,yaml}.jsonc` in pkg files**
- **changeset**
